### PR TITLE
MODTEMPENG-111 support barcode image generation for `Hrid` tokens

### DIFF
--- a/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
+++ b/src/main/java/org/folio/template/util/TemplateContextPreProcessor.java
@@ -36,6 +36,7 @@ public class TemplateContextPreProcessor {
   private static final String SUFFIX_DATE = "Date";
   private static final String SUFFIX_TIME = "Time";
   private static final String SUFFIX_BARCODE = ".barcode";
+  private static final String SUFFIX_HRID = "Hrid";
   private static final String SUFFIX_IMAGE = "Image";
 
   private final LocalizedTemplatesProperty template;
@@ -62,7 +63,7 @@ public class TemplateContextPreProcessor {
   }
 
   public void process() {
-    LOG.debug("process:: Started processsing");
+    LOG.debug("process:: Started processing");
     enrichContextWithDateTimes();
     formatDatesInContext(context, config.getLanguageTag(), config.getTimeZoneId());
     handleBarcodeImageTokens();
@@ -84,7 +85,7 @@ public class TemplateContextPreProcessor {
     Set<String> newTokens = new HashSet<>();
 
     contextMap.entrySet().stream()
-      .filter(e -> e.getKey().endsWith(SUFFIX_BARCODE))
+      .filter(e -> isSuitableImageSource(e.getKey()))
       .filter(e -> objectIsNonBlankString(e.getValue()))
       .map(e -> new Token(e.getKey(), (String) e.getValue()))
       .filter(token -> templateTokens.contains(token.shortPath() + SUFFIX_IMAGE))
@@ -101,6 +102,10 @@ public class TemplateContextPreProcessor {
     // For HTML to be interpreted correctly by Mustache,
     // tokens must be wrapped in triple curly braces: "{{{...}}}"
     fixTokensWithHtmlValue(newTokens);
+  }
+
+  private boolean isSuitableImageSource(String tokenKey) {
+      return tokenKey.endsWith(SUFFIX_BARCODE) || tokenKey.endsWith(SUFFIX_HRID);
   }
 
   private boolean objectIsNonBlankString(Object obj) {


### PR DESCRIPTION
  - i.e. for token `item.instanceHrid`

## Purpose
_Describe the purpose of the pull request. Include background information if necessary._

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Changes checklist
- [ ] Check logging.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Screenshots
_Let's see those sweet visuals!_
